### PR TITLE
 gbounds handling for custom constraints

### DIFF
--- a/biorbd_optim/limits/penalty.py
+++ b/biorbd_optim/limits/penalty.py
@@ -428,7 +428,7 @@ class PenaltyFunctionAbstract:
                         penalty.type.get_type().add_to_penalty(ocp, nlp, val, penalty, **extra_param)
 
         @staticmethod
-        def custom(penalty, ocp, nlp, t, x, u, p, **parameters):
+        def custom(penalty, ocp, nlp, t, x, u, p, min_bound=0, max_bound=0, **parameters):
             """
             Adds a custom penalty function (objective or constraint).
             :param parameters: parameters["function"] -> Penalty function (CasADi function),
@@ -436,7 +436,7 @@ class PenaltyFunctionAbstract:
             (float)
             """
             val = penalty.custom_function(ocp, nlp, t, x, u, p, **parameters)
-            penalty.type.get_type().add_to_penalty(ocp, nlp, val, penalty)
+            penalty.type.get_type().add_to_penalty(ocp, nlp, val, penalty, min_bound, max_bound)
 
     @staticmethod
     def add(ocp, nlp):

--- a/examples/muscle_driven_ocp/muscle_activations_tracker.py
+++ b/examples/muscle_driven_ocp/muscle_activations_tracker.py
@@ -17,7 +17,7 @@ from biorbd_optim import (
     BoundsList,
     QAndQDotBounds,
     InitialConditionsList,
-    Solver
+    Solver,
 )
 
 
@@ -170,8 +170,16 @@ def prepare_ocp(
     # ------------- #
 
     return OptimalControlProgram(
-        biorbd_model, dynamics, nb_shooting, final_time, x_init, u_init, x_bounds,
-        u_bounds, objective_functions, use_SX= use_SX,
+        biorbd_model,
+        dynamics,
+        nb_shooting,
+        final_time,
+        x_init,
+        u_init,
+        x_bounds,
+        u_bounds,
+        objective_functions,
+        use_SX=use_SX,
     )
 
 
@@ -199,7 +207,6 @@ if __name__ == "__main__":
         kin_data_to_track="q",
         use_residual_torque=use_residual_torque,
         use_SX=False,
-
     )
 
     # --- Solve the program --- #

--- a/examples/muscle_driven_ocp/static_arm.py
+++ b/examples/muscle_driven_ocp/static_arm.py
@@ -74,19 +74,27 @@ if __name__ == "__main__":
 
     # --- Solve the program --- #
     tic = time()
-    sol_ac = ocp.solve(solver=Solver.ACADOS, show_online_optim=False, solver_options={"nlp_solver_tol_comp": 1e-3,
-                                                                                      "nlp_solver_tol_eq": 1e-3,
-                                                                                      "nlp_solver_tol_stat": 1e-3,})
+    sol_ac = ocp.solve(
+        solver=Solver.ACADOS,
+        show_online_optim=False,
+        solver_options={"nlp_solver_tol_comp": 1e-3, "nlp_solver_tol_eq": 1e-3, "nlp_solver_tol_stat": 1e-3,},
+    )
     toc = time() - tic
     print(f"Time to solve with ACADOS: {toc}sec")
 
     ocp = prepare_ocp(biorbd_model_path="arm26.bioMod", final_time=2, number_shooting_points=20, use_SX=False)
     tic = time()
-    sol_ip = ocp.solve(solver=Solver.IPOPT, show_online_optim=False, solver_options={"tol": 1e-3,
-                                                                                      "dual_inf_tol": 1e-3,
-                                                                                      "constr_viol_tol": 1e-3,
-                                                                                      "compl_inf_tol": 1e-3,
-                                                                                      "linear_solver": "ma57"})
+    sol_ip = ocp.solve(
+        solver=Solver.IPOPT,
+        show_online_optim=False,
+        solver_options={
+            "tol": 1e-3,
+            "dual_inf_tol": 1e-3,
+            "constr_viol_tol": 1e-3,
+            "compl_inf_tol": 1e-3,
+            "linear_solver": "ma57",
+        },
+    )
     toc = time() - tic
     print(f"Time to solve with ACADOS: {toc}sec")
 


### PR DESCRIPTION
Custom constraint behavior is based on the value "val" returned by the custom constraint function in the user ocp. But BiorbdOptim forced this value to be null : the aim of this PR is to give the possibility to just force this value to be between bounds written by the user.